### PR TITLE
Change license key env variable to api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 To track your deployments on New Relic you need to configure two environments vars:
 
-    dokku config:set appname NEW_RELIC_LICENSE_KEY=your-license-key
+    dokku config:set appname NEW_RELIC_API_KEY=your-api-key
 
 And at least one of these:
 
     dokku config:set appname NEW_RELIC_APP_NAME=your-application-name
-or 
-    dokku config:set appname NEW_RELIC_APPLICATION_ID=your-application-id
 
 Like any configuration vars in dokku they will be exported so you can use it in your
 application tracking.

--- a/post-deploy
+++ b/post-deploy
@@ -15,7 +15,7 @@ if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
         NEW_RELIC_APP_NAME)
           CURL_OPTS+=" --data deployment[app_name]=${val//\'/}";
         ;;
-        NEW_RELIC_LICENSE_KEY)
+        NEW_RELIC_API_KEY)
           CURL_OPTS+=" --header x-api-key:${val//\'/}";
         ;;
       esac


### PR DESCRIPTION
Since api key used for deploy notification is different than newrelic license key, and newrelic node.js apps  use environment variables to set up newrelic APM, this was causing a collision, where you could use either APM or deployment notifications via the plugin.
